### PR TITLE
Fix error in texi2pod introduced with Perl 5.18

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-06-17  Dave Reisner  <dreisner@archlinux.org>
+
+       * texi2pod.pl: Fix formatting error that causes build to fail with
+       Perl 5.18
+
 2012-10-07  Giuseppe Scrivano  <gscrivano@gnu.org>
 
 	* configure.ac: Check for patchconf.

--- a/doc/texi2pod.pl
+++ b/doc/texi2pod.pl
@@ -291,7 +291,7 @@ while(<$inf>) {
 	if (defined $1) {
             my $thing = $1;
             if ($ic =~ /\@asis/) {
-                $_ = "\n=item $thing\n";
+                $_ = "\n=item C<$thing>\n";
             } else {
                 # Entity escapes prevent munging by the <> processing below.
                 $_ = "\n=item $ic\&LT;$thing\&GT;\n";


### PR DESCRIPTION
Backport of a patch from Dave Reisner dreisner@archlinux.org found at https://lists.gnu.org/archive/html/bug-wget/2013-06/msg00046.html :
2013-06-17  Dave Reisner  dreisner@archlinux.org

```
* texi2pod.pl: Fix formatting error that causes build to fail with
Perl 5.18
```
