### PR TITLE
Remove doc, util & tests from build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ distuninstallcheck_listfiles = find . -type f | \
 ACLOCAL_AMFLAGS = -I m4
 
 # subdirectories in the distribution
-SUBDIRS = lib src doc po tests util
+SUBDIRS = lib src po
 
 EXTRA_DIST = ChangeLog.README MAILING-LIST \
              msdos/ChangeLog msdos/config.h msdos/Makefile.DJ \


### PR DESCRIPTION
This program is only used by ArchiveTeam's pipeline so remove what we will
never use so we will not waste time and we will not fail to build because
wget.pod is invalid under recent pod2man (fix #2 :) ).
