### PR TITLE
wget.callbacks.httploop_proceed_p can script local filenames

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -2654,7 +2654,7 @@ read_header:
   else
     *dt &= ~TEXTCSS;
 
-  if (opt.adjust_extension)
+  if (opt.adjust_extension && ! hs->override_filename)
     {
       if (*dt & TEXTHTML)
         /* -E / --adjust-extension / adjust_extension = on was specified,

--- a/src/http.h
+++ b/src/http.h
@@ -59,6 +59,7 @@ struct http_stat
   wgint orig_file_size;         /* size of file to compare for time-stamping */
   time_t orig_file_tstamp;      /* time-stamp of file to compare for
                                  * time-stamping */
+  bool override_filename;       // Ignore extension chosen by '-E' (for lua)
 };
 
 uerr_t http_loop (struct url *, struct url *, char **, char **, const char *,

--- a/src/luahooks.h
+++ b/src/luahooks.h
@@ -25,7 +25,7 @@ struct luahooks_url
 
 void luahooks_init ();
 const char *luahooks_lookup_host (const char *host);
-bool luahooks_httploop_proceed_p(const struct url *url, const struct http_stat *hstat);
+bool luahooks_httploop_proceed_p(const struct url *url, struct http_stat *hstat);
 luahook_action_t luahooks_httploop_result (const struct url *url,
                     const uerr_t err, const struct http_stat *hstat);
 bool luahooks_download_child_p (const struct urlpos *upos,


### PR DESCRIPTION
by returning a table (implies PROCEED) with:
- local_filename="string"
  this will override extensions set by -E unless:
- override_fiilename=0
  is set

example:

wget.callbacks.httploop_proceed_p = function(url, http_stat)
  return {
    local_file="foobar/"..http_stat.local_file.."silly_ext",
    override_filename=1
  }
end
